### PR TITLE
Added step 0 for Cython dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ If you want to cite this work in your publication:
 ```
 
 ### Installation
+0. Install Dependency
+    ```Shell
+       sudo pip install Cython
+    ``` 
+    
 1. Clone the Faster R-CNN repository
     ```Shell
     # Make sure to clone with --recursive


### PR DESCRIPTION
If Cython is not preinstalled to the python packages make file will not work